### PR TITLE
chore: add macos builds

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -144,7 +144,23 @@ jobs:
             run-e2e: false
             vulkan: false
             ccache: true
-            ccache-dir: "/home/runner/.ccache"          
+            ccache-dir: "/home/runner/.ccache"       
+          - os: "macos"
+            name: "x64"
+            runs-on: "macos-selfhosted-12"
+            cmake-flags: "-DGGML_METAL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+            run-e2e: false
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "macos"
+            name: "arm64"
+            runs-on: "macos-selfhosted-12-arm64"
+            cmake-flags: "-DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+            run-e2e: false
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'   
           - os: "win"
             name: "noavx-cuda-cu12.0-x64"
             runs-on: "windows-cuda-12-0"


### PR DESCRIPTION
This pull request introduces changes to the Menlo build workflow configuration to include additional macOS build targets. The most important changes are listed below:

### Workflow Configuration Updates:

* [`.github/workflows/menlo-build.yml`](diffhunk://#diff-b33a723c0ec237567c1e3beb2a35862c6ae91fd2f16d87f93e24b4ccd0509ae9R148-R163): Added new macOS build targets for both x64 and arm64 architectures with specific configurations for `cmake-flags`, `run-e2e`, `vulkan`, and `ccache` settings.