### PR TITLE
chore: change flag builds for macos

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -148,7 +148,7 @@ jobs:
           - os: "macos"
             name: "x64"
             runs-on: "macos-selfhosted-12"
-            cmake-flags: "-DGGML_METAL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+            cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
             run-e2e: false
             vulkan: false
             ccache: false
@@ -156,7 +156,7 @@ jobs:
           - os: "macos"
             name: "arm64"
             runs-on: "macos-selfhosted-12-arm64"
-            cmake-flags: "-DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+            cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
             run-e2e: false
             vulkan: false
             ccache: false


### PR DESCRIPTION
This pull request includes updates to the build configuration for macOS in the `.github/workflows/menlo-build.yml` file. The changes primarily focus on modifying the `cmake-flags` for different macOS build environments.

Build configuration updates:

* Added `-DCMAKE_BUILD_RPATH="@loader_path"` to the `cmake-flags` for the `x64` macOS build to set the runtime search path for shared libraries.
* Added `-DGGML_METAL_USE_BF16=ON` to the `cmake-flags` for the `arm64` macOS build to enable BF16 support in GGML Metal.