### PR TITLE
fix: align cuda-rt names

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -442,10 +442,10 @@ jobs:
     steps:
       - name: Download cuda dependencies from s3 and create checksum
         run: |
-          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/12.0/linux/cuda.tar.gz -O /tmp/cuda-12-0-linux-amd64.tar.gz
-          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/11.7/linux/cuda.tar.gz -O /tmp/cuda-11-7-linux-amd64.tar.gz
-          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/12.0/windows/cuda.tar.gz -O /tmp/cuda-12-0-windows-amd64.tar.gz
-          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/11.7/windows/cuda.tar.gz -O /tmp/cuda-11-7-windows-amd64.tar.gz
+          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/12.0/linux/cuda.tar.gz -O /tmp/cudart-llama-bin-linux-cu12.0-x64.tar.gz
+          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/11.7/linux/cuda.tar.gz -O /tmp/cudart-llama-bin-linux-cu11.7-x64.tar.gz
+          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/12.0/windows/cuda.tar.gz -O /tmp/cudart-llama-bin-win-cu12.0-64.tar.gz
+          wget https://minio.menlo.ai:9000/cicd/dist/cuda-dependencies/11.7/windows/cuda.tar.gz -O /tmp/cudart-llama-bin-win-cu11.7-x64.tar.gz
 
           version=${{ needs.create-draft-release.outputs.version }}
           outputs=${{ toJson(needs.read.outputs.result) }}
@@ -462,25 +462,25 @@ jobs:
             "- url: llama-\($version)-\($key).tar.gz\n  sha512: >-\n    \($sha512[$key])\n  size: \($size[$key])"
           ' >> checksum.yml
 
-          echo "- url: cuda-12-0-linux-amd64.tar.gz" >> checksum.yml
+          echo "- url: cudart-llama-bin-linux-cu12.0-x64.tar.gz" >> checksum.yml
           echo "  sha512: >-" >> checksum.yml
-          echo "    $(sha512sum /tmp/cuda-12-0-linux-amd64.tar.gz | awk '{ print $1 }')" >> checksum.yml
-          echo "  size: $(stat -c%s /tmp/cuda-12-0-linux-amd64.tar.gz)" >> checksum.yml
+          echo "    $(sha512sum /tmp/cudart-llama-bin-linux-cu12.0-x64.tar.gz | awk '{ print $1 }')" >> checksum.yml
+          echo "  size: $(stat -c%s /tmp/cudart-llama-bin-linux-cu12.0-x64.tar.gz)" >> checksum.yml
 
-          echo "- url: cuda-11-7-linux-amd64.tar.gz" >> checksum.yml
+          echo "- url: cudart-llama-bin-linux-cu11.7-x64.tar.gz" >> checksum.yml
           echo "  sha512: >-" >> checksum.yml
-          echo "    $(sha512sum /tmp/cuda-11-7-linux-amd64.tar.gz | awk '{ print $1 }')" >> checksum.yml
-          echo "  size: $(stat -c%s /tmp/cuda-11-7-linux-amd64.tar.gz)" >> checksum.yml
+          echo "    $(sha512sum /tmp/cudart-llama-bin-linux-cu11.7-x64.tar.gz | awk '{ print $1 }')" >> checksum.yml
+          echo "  size: $(stat -c%s /tmp/cudart-llama-bin-linux-cu11.7-x64.tar.gz)" >> checksum.yml
 
-          echo "- url: cuda-11-7-windows-amd64.tar.gz" >> checksum.yml
+          echo "- url: cudart-llama-bin-win-cu11.7-x64.tar.gz" >> checksum.yml
           echo "  sha512: >-" >> checksum.yml
-          echo "    $(sha512sum /tmp/cuda-11-7-windows-amd64.tar.gz | awk '{ print $1 }')" >> checksum.yml
-          echo "  size: $(stat -c%s /tmp/cuda-11-7-windows-amd64.tar.gz)" >> checksum.yml
+          echo "    $(sha512sum /tmp/cudart-llama-bin-win-cu11.7-x64.tar.gz | awk '{ print $1 }')" >> checksum.yml
+          echo "  size: $(stat -c%s /tmp/cudart-llama-bin-win-cu11.7-x64.tar.gz)" >> checksum.yml
 
-          echo "- url: cuda-12-0-windows-amd64.tar.gz" >> checksum.yml
+          echo "- url: cudart-llama-bin-win-cu12.4.tar.gz" >> checksum.yml
           echo "  sha512: >-" >> checksum.yml
-          echo "    $(sha512sum /tmp/cuda-12-0-windows-amd64.tar.gz | awk '{ print $1 }')" >> checksum.yml
-          echo "  size: $(stat -c%s /tmp/cuda-12-0-windows-amd64.tar.gz)" >> checksum.yml
+          echo "    $(sha512sum /tmp/cudart-llama-bin-win-cu12.4.tar.gz | awk '{ print $1 }')" >> checksum.yml
+          echo "  size: $(stat -c%s /tmp/cudart-llama-bin-win-cu12.4.tar.gz)" >> checksum.yml
           cat checksum.yml
 
       - name: Upload checksum.yml to GitHub Release
@@ -494,46 +494,46 @@ jobs:
           asset_name: checksum.yml
           asset_content_type: text/yaml
 
-      - name: upload cuda-12-0-linux-amd64.tar.gz to Github Release
+      - name: upload cudart-llama-bin-linux-cu12.0-x64.tar.gz to Github Release
         uses: actions/upload-release-asset@v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-draft-release.outputs.upload_url }}
-          asset_path: /tmp/cuda-12-0-linux-amd64.tar.gz
-          asset_name: cuda-12-0-linux-amd64.tar.gz
+          asset_path: /tmp/cudart-llama-bin-linux-cu12.0-x64.tar.gz
+          asset_name: cudart-llama-bin-linux-cu12.0-x64.tar.gz
           asset_content_type: application/gzip
       
-      - name: upload cuda-11-7-linux-amd64.tar.gz to Github Release
+      - name: upload cudart-llama-bin-linux-cu11.7-x64.tar.gz to Github Release
         uses: actions/upload-release-asset@v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-draft-release.outputs.upload_url }}
-          asset_path: /tmp/cuda-11-7-linux-amd64.tar.gz
-          asset_name: cuda-11-7-linux-amd64.tar.gz
+          asset_path: /tmp/cudart-llama-bin-linux-cu11.7-x64.tar.gz
+          asset_name: cudart-llama-bin-linux-cu11.7-x64.tar.gz
           asset_content_type: application/gzip
       
-      - name: upload cuda-12-0-windows-amd64.tar.gz to Github Release
+      - name: upload cudart-llama-bin-win-cu12.4.tar.gz to Github Release
         uses: actions/upload-release-asset@v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-draft-release.outputs.upload_url }}
-          asset_path: /tmp/cuda-12-0-windows-amd64.tar.gz
-          asset_name: cuda-12-0-windows-amd64.tar.gz
+          asset_path: /tmp/cudart-llama-bin-win-cu12.4.tar.gz
+          asset_name: cudart-llama-bin-win-cu12.4.tar.gz
           asset_content_type: application/gzip
       
-      - name: upload cuda-11-7-windows-amd64.tar.gz to Github Release
+      - name: upload cudart-llama-bin-win-cu11.7-x64.tar.gz to Github Release
         uses: actions/upload-release-asset@v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-draft-release.outputs.upload_url }}
-          asset_path: /tmp/cuda-11-7-windows-amd64.tar.gz
-          asset_name: cuda-11-7-windows-amd64.tar.gz
+          asset_path: /tmp/cudart-llama-bin-win-cu11.7-x64.tar.gz
+          asset_name: cudart-llama-bin-win-cu11.7-x64.tar.gz
           asset_content_type: application/gzip


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/menlo-build.yml` file to rename CUDA dependency files for better clarity and consistency. The changes affect the download, checksum generation, and upload steps in the GitHub Actions workflow.

Key changes include:

* Updated file names for downloading CUDA dependencies to follow a new naming convention.
* Modified checksum generation commands to reflect the new file names.
* Changed asset names and paths in the upload steps to match the new naming convention.