### PR TITLE
chore: update upstream sync ci

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -156,10 +156,18 @@ jobs:
 
         git fetch origin dev
         git checkout -B dev origin/dev
-        
+    
         # Create tag using master branch commit count
         TAG_NAME="b$COMMIT_COUNT"
-        
+
+        # Delete the tag if it already exists (both locally and remotely)
+        if git tag -l "$TAG_NAME" | grep -q "$TAG_NAME"; then
+          echo "Tag $TAG_NAME already exists. Deleting it first..."
+          git tag -d "$TAG_NAME" || true
+          git push --delete origin "$TAG_NAME" || true
+          echo "Existing tag deleted."
+        fi
+
         # Create tag on the current commit (dev branch HEAD after merge)
         git tag "$TAG_NAME"
         git push origin "$TAG_NAME"


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/upstream-sync.yml` file. The change ensures that if a tag with the same name already exists, it will be deleted both locally and remotely before creating a new tag with the same name.

* [`.github/workflows/upstream-sync.yml`](diffhunk://#diff-f21bf02175f33f2522bf5ac7944d2999c7f4ea8b8542afe361a9800eda3580e9R163-R170): Added a check to delete the tag if it already exists both locally and remotely before creating a new tag.