### PR TITLE
fix: codesign macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ else ifeq ($(shell uname -s),Linux)
 	@echo "Skipping Code Sign for linux"
 	@exit 0
 else
-	find "llama" -type f -exec codesign --force -s "$(DEVELOPER_ID)" --options=runtime {} \;
+	find "build/bin" -type f -exec codesign --force -s "$(DEVELOPER_ID)" --options=runtime {} \;
 endif
 
 package:


### PR DESCRIPTION
This pull request includes a small but important update to the `Makefile`. The change ensures that the `codesign` command targets the correct directory for signing binaries on Linux.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L45-R45): Updated the `codesign` command to target the `build/bin` directory instead of the `llama` directory, ensuring the correct files are signed.
