### PR TITLE
feat: add vulkan build

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -60,94 +60,94 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: "linux"
-          #   name: "noavx-x64"
-          #   runs-on: "ubuntu-20-04"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx-x64"
-          #   runs-on: "ubuntu-20-04"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx512-x64"
-          #   runs-on: "ubuntu-20-04"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "noavx-cuda-cu11.7-x64"
-          #   runs-on: "ubuntu-20-04-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx2-cuda-cu11.7-x64"
-          #   runs-on: "ubuntu-20-04-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx-cuda-cu11.7-x64"
-          #   runs-on: "ubuntu-20-04-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx512-cuda-cu11.7-x64"
-          #   runs-on: "ubuntu-20-04-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "noavx-cuda-cu12.0-x64"
-          #   runs-on: "ubuntu-20-04-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx2-cuda-cu12.0-x64"
-          #   runs-on: "ubuntu-20-04-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx-cuda-cu12.0-x64"
-          #   runs-on: "ubuntu-20-04-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache"
-          # - os: "linux"
-          #   name: "avx512-cuda-cu12.0-x64"
-          #   runs-on: "ubuntu-20-04-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: "/home/runner/.ccache" 
+          - os: "linux"
+            name: "noavx-x64"
+            runs-on: "ubuntu-20-04"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx-x64"
+            runs-on: "ubuntu-20-04"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx512-x64"
+            runs-on: "ubuntu-20-04"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "noavx-cuda-cu11.7-x64"
+            runs-on: "ubuntu-20-04-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx2-cuda-cu11.7-x64"
+            runs-on: "ubuntu-20-04-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx-cuda-cu11.7-x64"
+            runs-on: "ubuntu-20-04-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx512-cuda-cu11.7-x64"
+            runs-on: "ubuntu-20-04-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "noavx-cuda-cu12.0-x64"
+            runs-on: "ubuntu-20-04-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx2-cuda-cu12.0-x64"
+            runs-on: "ubuntu-20-04-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx-cuda-cu12.0-x64"
+            runs-on: "ubuntu-20-04-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
+          - os: "linux"
+            name: "avx512-cuda-cu12.0-x64"
+            runs-on: "ubuntu-20-04-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: "/home/runner/.ccache" 
           - os: "linux"
             name: "vulkan-x64"
             runs-on: "ubuntu-22-04"
@@ -156,118 +156,118 @@ jobs:
             vulkan: true
             ccache: true
             ccache-dir: "/home/runner/.ccache"
-          # - os: "macos"
-          #   name: "x64"
-          #   runs-on: "macos-selfhosted-12"
-          #   cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: false
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "macos"
-          #   name: "arm64"
-          #   runs-on: "macos-selfhosted-12-arm64"
-          #   cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: false
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'   
-          # - os: "win"
-          #   name: "noavx-cuda-cu12.0-x64"
-          #   runs-on: "windows-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx2-cuda-cu12.0-x64"
-          #   runs-on: "windows-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx-cuda-cu12.0-x64"
-          #   runs-on: "windows-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx512-cuda-cu12.0-x64"
-          #   runs-on: "windows-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "noavx-cuda-cu11.7-x64"
-          #   runs-on: "windows-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx2-cuda-cu11.7-x64"
-          #   runs-on: "windows-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx-cuda-cu11.7-x64"
-          #   runs-on: "windows-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx512-cuda-cu11.7-x64"
-          #   runs-on: "windows-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: true
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx2-x64"
-          #   runs-on: "windows-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-          #   run-e2e: true
-          #   vulkan: false
-          #   ccache: false
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "noavx-x64"
-          #   runs-on: "windows-cuda-11-7"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DBUILD_SHARED_LIBS=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: false
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx-x64"
-          #   runs-on: "windows-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-          #   run-e2e: true
-          #   vulkan: false
-          #   ccache: false
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          # - os: "win"
-          #   name: "avx512-x64"
-          #   runs-on: "windows-cuda-12-0"
-          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-          #   run-e2e: false
-          #   vulkan: false
-          #   ccache: false
-          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "macos"
+            name: "x64"
+            runs-on: "macos-selfhosted-12"
+            cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+            run-e2e: false
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "macos"
+            name: "arm64"
+            runs-on: "macos-selfhosted-12-arm64"
+            cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+            run-e2e: false
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'   
+          - os: "win"
+            name: "noavx-cuda-cu12.0-x64"
+            runs-on: "windows-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx2-cuda-cu12.0-x64"
+            runs-on: "windows-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx-cuda-cu12.0-x64"
+            runs-on: "windows-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx512-cuda-cu12.0-x64"
+            runs-on: "windows-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "noavx-cuda-cu11.7-x64"
+            runs-on: "windows-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx2-cuda-cu11.7-x64"
+            runs-on: "windows-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx-cuda-cu11.7-x64"
+            runs-on: "windows-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx512-cuda-cu11.7-x64"
+            runs-on: "windows-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: true
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx2-x64"
+            runs-on: "windows-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            run-e2e: true
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "noavx-x64"
+            runs-on: "windows-cuda-11-7"
+            cmake-flags: "-DLLAMA_CURL=OFF -DBUILD_SHARED_LIBS=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx-x64"
+            runs-on: "windows-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            run-e2e: true
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "avx512-x64"
+            runs-on: "windows-cuda-12-0"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            run-e2e: false
+            vulkan: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
           - os: "win"
             name: "vulkan-x64"
             runs-on: "windows-cuda-11-7"

--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -346,25 +346,19 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y build-essential vulkan-sdk
     
-      # - name: Prepare Vulkan SDK Windows
-      #   if: ${{ matrix.vulkan && (matrix.os == 'win') }}
-      #   # continue-on-error: true
-      #   run: |
-      #     curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
-      #     Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
-      #     Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
-
       - name: Prepare Vulkan SDK Windows
-        if: ${{ matrix.vulkan && matrix.os == 'win' }}
-        shell: pwsh
+        if: ${{ matrix.vulkan && (matrix.os == 'win') }}
+        # continue-on-error: true
         run: |
-          $version = "${{ env.VULKAN_VERSION }}"
-          $url = "https://sdk.lunarg.com/sdk/download/$version/windows/VulkanSDK-$version-Installer.exe"
-          $installer = "$env:RUNNER_TEMP\VulkanSDK-Installer.exe"
-          Invoke-WebRequest -Uri $url -OutFile $installer
-          Start-Process -FilePath $installer -ArgumentList "--accept-licenses", "--default-answer", "--confirm-command", "install" -Wait
-          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\$version"
-          Add-Content $env:GITHUB_PATH "C:\VulkanSDK\$version\Bin"
+          Write-Host "VULKAN_VERSION: $env:VULKAN_VERSION"
+          $url = "https://sdk.lunarg.com/sdk/download/$env:VULKAN_VERSION/windows/VulkanSDK-$env:VULKAN_VERSION-Installer.exe"
+          Write-Host "Downloading from URL: $url"
+          curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
+          Write-Host "Expected VULKAN_SDK path: C:\VulkanSDK\$env:VULKAN_VERSION"
+          Write-Host "Expected PATH addition: C:\VulkanSDK\$env:VULKAN_VERSION\bin"
+          # https://sdk.lunarg.com/sdk/download/1.3.261.1/windows/VulkanSDK-1.3.261.1-Installer.exe
+          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
+          Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
 
       - name: Get Cer for code signing
         if: runner.os == 'macOS'

--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -23,6 +23,9 @@ on:
       ]
   workflow_dispatch:
 
+env:
+  VULKAN_VERSION: 1.3.261.1
+
 jobs:
   create-draft-release:
     runs-on: ubuntu-latest
@@ -38,7 +41,6 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV && echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
         env:
           GITHUB_REF: ${{ github.ref }}
-          VULKAN_VERSION: 1.3.261.1
       - name: Create Draft Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -350,13 +352,8 @@ jobs:
         if: ${{ matrix.vulkan && (matrix.os == 'win') }}
         # continue-on-error: true
         run: |
-          Write-Host "VULKAN_VERSION: $env:VULKAN_VERSION"
-          $url = "https://sdk.lunarg.com/sdk/download/$env:VULKAN_VERSION/windows/VulkanSDK-$env:VULKAN_VERSION-Installer.exe"
-          Write-Host "Downloading from URL: $url"
           curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
-          Write-Host "Expected VULKAN_SDK path: C:\VulkanSDK\$env:VULKAN_VERSION"
-          Write-Host "Expected PATH addition: C:\VulkanSDK\$env:VULKAN_VERSION\bin"
-          # https://sdk.lunarg.com/sdk/download/1.3.261.1/windows/VulkanSDK-1.3.261.1-Installer.exe
+          & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
           Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
 

--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -38,6 +38,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV && echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
         env:
           GITHUB_REF: ${{ github.ref }}
+          VULKAN_VERSION: 1.3.261.1
       - name: Create Draft Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -144,7 +145,15 @@ jobs:
             run-e2e: false
             vulkan: false
             ccache: true
-            ccache-dir: "/home/runner/.ccache"       
+            ccache-dir: "/home/runner/.ccache" 
+          - os: "linux"
+            name: "vulkan-x64"
+            runs-on: "ubuntu-22-04"
+            cmake-flags: "-DBUILD_SHARED_LIBS=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_VULKAN=ON -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            run-e2e: false
+            vulkan: true
+            ccache: true
+            ccache-dir: "/home/runner/.ccache"
           - os: "macos"
             name: "x64"
             runs-on: "macos-selfhosted-12"
@@ -257,6 +266,14 @@ jobs:
             vulkan: false
             ccache: false
             ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          - os: "win"
+            name: "vulkan-x64"
+            runs-on: "windows-cuda-11-7"
+            cmake-flags: "-DBUILD_SHARED_LIBS=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_VULKAN=ON -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            vulkan: true
+            run-e2e: false
+            ccache: false
+            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
           
 
     steps:
@@ -320,6 +337,23 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install coreutils
+      
+      - name: Prepare Vulkan SDK Linux
+        if: ${{ matrix.vulkan && (matrix.os == 'linux') }}
+        run: |
+          wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential vulkan-sdk
+    
+      - name: Prepare Vulkan SDK Windows
+        if: ${{ matrix.vulkan && (matrix.os == 'windows') }}
+        continue-on-error: true
+        run: |
+          curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
+          & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
+          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
+          Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
 
       - name: Get Cer for code signing
         if: runner.os == 'macOS'

--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -347,7 +347,7 @@ jobs:
           sudo apt-get install -y build-essential vulkan-sdk
     
       - name: Prepare Vulkan SDK Windows
-        if: ${{ matrix.vulkan && (matrix.os == 'windows') }}
+        if: ${{ matrix.vulkan && (matrix.os == 'win') }}
         continue-on-error: true
         run: |
           curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"

--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -346,21 +346,25 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y build-essential vulkan-sdk
     
+      # - name: Prepare Vulkan SDK Windows
+      #   if: ${{ matrix.vulkan && (matrix.os == 'win') }}
+      #   # continue-on-error: true
+      #   run: |
+      #     curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
+      #     Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
+      #     Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
+
       - name: Prepare Vulkan SDK Windows
-        if: ${{ matrix.vulkan && (matrix.os == 'win') }}
-        # continue-on-error: true
-        run: |
-          curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
-          & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
-          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
-          Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
-      - name: Debug Vulkan SDK env
-        if: ${{ matrix.vulkan && runner.os == 'win' }}
-        run: |
-          echo "VULKAN_SDK=$env:VULKAN_SDK"
-          dir "C:\VulkanSDK\1.3.261.1\Include\vulkan"
-          where glslc
+        if: ${{ matrix.vulkan && matrix.os == 'win' }}
         shell: pwsh
+        run: |
+          $version = "${{ env.VULKAN_VERSION }}"
+          $url = "https://sdk.lunarg.com/sdk/download/$version/windows/VulkanSDK-$version-Installer.exe"
+          $installer = "$env:RUNNER_TEMP\VulkanSDK-Installer.exe"
+          Invoke-WebRequest -Uri $url -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList "--accept-licenses", "--default-answer", "--confirm-command", "install" -Wait
+          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\$version"
+          Add-Content $env:GITHUB_PATH "C:\VulkanSDK\$version\Bin"
 
       - name: Get Cer for code signing
         if: runner.os == 'macOS'

--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -58,94 +58,94 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "linux"
-            name: "noavx-x64"
-            runs-on: "ubuntu-20-04"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx-x64"
-            runs-on: "ubuntu-20-04"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx512-x64"
-            runs-on: "ubuntu-20-04"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "noavx-cuda-cu11.7-x64"
-            runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx2-cuda-cu11.7-x64"
-            runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx-cuda-cu11.7-x64"
-            runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx512-cuda-cu11.7-x64"
-            runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "noavx-cuda-cu12.0-x64"
-            runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx2-cuda-cu12.0-x64"
-            runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx-cuda-cu12.0-x64"
-            runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache"
-          - os: "linux"
-            name: "avx512-cuda-cu12.0-x64"
-            runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: "/home/runner/.ccache" 
+          # - os: "linux"
+          #   name: "noavx-x64"
+          #   runs-on: "ubuntu-20-04"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx-x64"
+          #   runs-on: "ubuntu-20-04"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx512-x64"
+          #   runs-on: "ubuntu-20-04"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "noavx-cuda-cu11.7-x64"
+          #   runs-on: "ubuntu-20-04-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx2-cuda-cu11.7-x64"
+          #   runs-on: "ubuntu-20-04-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx-cuda-cu11.7-x64"
+          #   runs-on: "ubuntu-20-04-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx512-cuda-cu11.7-x64"
+          #   runs-on: "ubuntu-20-04-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "noavx-cuda-cu12.0-x64"
+          #   runs-on: "ubuntu-20-04-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx2-cuda-cu12.0-x64"
+          #   runs-on: "ubuntu-20-04-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx-cuda-cu12.0-x64"
+          #   runs-on: "ubuntu-20-04-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache"
+          # - os: "linux"
+          #   name: "avx512-cuda-cu12.0-x64"
+          #   runs-on: "ubuntu-20-04-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: "/home/runner/.ccache" 
           - os: "linux"
             name: "vulkan-x64"
             runs-on: "ubuntu-22-04"
@@ -154,118 +154,118 @@ jobs:
             vulkan: true
             ccache: true
             ccache-dir: "/home/runner/.ccache"
-          - os: "macos"
-            name: "x64"
-            runs-on: "macos-selfhosted-12"
-            cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
-            run-e2e: false
-            vulkan: false
-            ccache: false
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "macos"
-            name: "arm64"
-            runs-on: "macos-selfhosted-12-arm64"
-            cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
-            run-e2e: false
-            vulkan: false
-            ccache: false
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'   
-          - os: "win"
-            name: "noavx-cuda-cu12.0-x64"
-            runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx2-cuda-cu12.0-x64"
-            runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx-cuda-cu12.0-x64"
-            runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx512-cuda-cu12.0-x64"
-            runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "noavx-cuda-cu11.7-x64"
-            runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx2-cuda-cu11.7-x64"
-            runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx-cuda-cu11.7-x64"
-            runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx512-cuda-cu11.7-x64"
-            runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: true
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx2-x64"
-            runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-            run-e2e: true
-            vulkan: false
-            ccache: false
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "noavx-x64"
-            runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DBUILD_SHARED_LIBS=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: false
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx-x64"
-            runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-            run-e2e: true
-            vulkan: false
-            ccache: false
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-          - os: "win"
-            name: "avx512-x64"
-            runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
-            run-e2e: false
-            vulkan: false
-            ccache: false
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "macos"
+          #   name: "x64"
+          #   runs-on: "macos-selfhosted-12"
+          #   cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: false
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "macos"
+          #   name: "arm64"
+          #   runs-on: "macos-selfhosted-12-arm64"
+          #   cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=ON"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: false
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'   
+          # - os: "win"
+          #   name: "noavx-cuda-cu12.0-x64"
+          #   runs-on: "windows-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx2-cuda-cu12.0-x64"
+          #   runs-on: "windows-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx-cuda-cu12.0-x64"
+          #   runs-on: "windows-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx512-cuda-cu12.0-x64"
+          #   runs-on: "windows-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "noavx-cuda-cu11.7-x64"
+          #   runs-on: "windows-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx2-cuda-cu11.7-x64"
+          #   runs-on: "windows-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx-cuda-cu11.7-x64"
+          #   runs-on: "windows-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx512-cuda-cu11.7-x64"
+          #   runs-on: "windows-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: true
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx2-x64"
+          #   runs-on: "windows-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+          #   run-e2e: true
+          #   vulkan: false
+          #   ccache: false
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "noavx-x64"
+          #   runs-on: "windows-cuda-11-7"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DBUILD_SHARED_LIBS=OFF -DLLAMA_BUILD_SERVER=ON -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: false
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx-x64"
+          #   runs-on: "windows-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+          #   run-e2e: true
+          #   vulkan: false
+          #   ccache: false
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # - os: "win"
+          #   name: "avx512-x64"
+          #   runs-on: "windows-cuda-12-0"
+          #   cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: false
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
           - os: "win"
             name: "vulkan-x64"
             runs-on: "windows-cuda-11-7"

--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -348,12 +348,19 @@ jobs:
     
       - name: Prepare Vulkan SDK Windows
         if: ${{ matrix.vulkan && (matrix.os == 'win') }}
-        continue-on-error: true
+        # continue-on-error: true
         run: |
           curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
           Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
+      - name: Debug Vulkan SDK env
+        if: ${{ matrix.vulkan && runner.os == 'win' }}
+        run: |
+          echo "VULKAN_SDK=$env:VULKAN_SDK"
+          dir "C:\VulkanSDK\1.3.261.1\Include\vulkan"
+          where glslc
+        shell: pwsh
 
       - name: Get Cer for code signing
         if: runner.os == 'macOS'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/menlo-build.yml` to add support for Vulkan builds on both Linux and Windows. The changes include defining a Vulkan version, adding new build matrix configurations, and preparing the Vulkan SDK for the respective platforms.

### Vulkan Support Enhancements:

* **Vulkan Version Definition**: Added `VULKAN_VERSION: 1.3.261.1` to the environment variables in the workflow to specify the Vulkan SDK version.

* **Linux Build Configuration**: Introduced a new build matrix entry for Vulkan on Linux, specifying CMake flags and other settings to enable Vulkan support.

* **Windows Build Configuration**: Added a new build matrix entry for Vulkan on Windows, with appropriate CMake flags and settings for Vulkan support.

* **Vulkan SDK Setup for Linux**: Added a step to install the Vulkan SDK on Linux, including fetching the signing key, updating the package list, and installing necessary packages.

* **Vulkan SDK Setup for Windows**: Added a step to download and install the Vulkan SDK on Windows, including setting up environment variables and updating the system path.
