### PR TITLE
ci: include menlo-build.yml in workflow trigger paths

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -7,6 +7,7 @@ on:
       [
         ".github/scripts/**",
         ".github/workflows/build.yml",
+        ".github/workflows/menlo-build.yml",
         "**/CMakeLists.txt",
         "**/Makefile",
         "**/*.h",


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to include additional files that trigger the workflow.

Workflow configuration updates:

* [`.github/workflows/menlo-build.yml`](diffhunk://#diff-b33a723c0ec237567c1e3beb2a35862c6ae91fd2f16d87f93e24b4ccd0509ae9R10): Added the file itself to the list of paths that trigger the workflow, ensuring changes to this file will now initiate the build process.