### PR TITLE
fix: build error missing endif

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ else ifeq ($(shell uname -s),Linux)
 	@tar -czvf llama.tar.gz build/bin;
 else
 	@tar -czvf llama.tar.gz build/bin;
+endif
+
 ifdef LLAMA_SANITIZE_THREAD
 	MK_CFLAGS   += -fsanitize=thread -g
 	MK_CXXFLAGS += -fsanitize=thread -g


### PR DESCRIPTION
This pull request makes a small fix to the `Makefile` by adding a missing `endif` statement to properly close the `else ifeq` block.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R55-R56): Added a missing `endif` to close the conditional block for `else ifeq ($(shell uname -s),Linux)`, ensuring correct syntax and behavior.