### PR TITLE
ci: enable continue-on-error for Vulkan SDK installation on Windows

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -350,7 +350,7 @@ jobs:
 
       - name: Prepare Vulkan SDK Windows
         if: ${{ matrix.vulkan && (matrix.os == 'win') }}
-        # continue-on-error: true
+        continue-on-error: true
         run: |
           curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/menlo-build.yml` file. The change re-enables the `continue-on-error` option for the "Prepare Vulkan SDK Windows" step in the workflow.

* [`.github/workflows/menlo-build.yml`](diffhunk://#diff-b33a723c0ec237567c1e3beb2a35862c6ae91fd2f16d87f93e24b4ccd0509ae9L353-R353): Set `continue-on-error: true` for the "Prepare Vulkan SDK Windows" step, allowing the workflow to proceed even if this step fails.