### PR TITLE
ci: menlo build windows arm upstream

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -56,7 +56,7 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.runs-on }}
     needs: [create-draft-release]
-    timeout-minutes: 90
+    timeout-minutes: 100
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/menlo-build.yml` file. The change increases the `timeout-minutes` value for the `build-and-test` job