### PR TITLE
chore: add notarization step for mac

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -399,6 +399,31 @@ jobs:
         run: |
           make codesign CODE_SIGN=true DEVELOPER_ID="${{ secrets.DEVELOPER_ID }}"
 
+      - name: Install Quill for notarization
+        if: runner.os == 'macOS'
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /usr/local/bin
+          quill --version
+
+      - name: Prepare notary key
+        if: runner.os == 'macOS'
+        run: |
+          base64 -d <<< "$NOTARIZE_P8_BASE64" > /tmp/notary-key.p8
+          chmod 600 /tmp/notary-key.p8
+        env:
+          NOTARIZE_P8_BASE64: ${{ secrets.NOTARIZE_P8_BASE64 }}
+
+      - name: Notarize macOS binaries
+        if: runner.os == 'macOS'
+        run: |
+          make notarize NOTARIZE=true QUILL_NOTARY_KEY_ID="${{ secrets.NOTARY_KEY_ID }}" QUILL_NOTARY_ISSUER="${{ secrets.NOTARY_ISSUER }}" QUILL_NOTARY_KEY="/tmp/notary-key.p8"
+
+      - name: Cleanup notary key
+        if: runner.os == 'macOS'
+        run: |
+          rm -f /tmp/notary-key.p8
+          echo "Notary key cleaned up"
+
       - name: Code Signing Windows
         if: runner.os == 'Windows'
         shell: cmd


### PR DESCRIPTION
This pull request introduces support for notarizing macOS binaries in the build process. The changes include updates to the GitHub Actions workflow, the `Makefile`, and the addition of a new `notarize` target to handle notarization logic. These updates ensure that macOS binaries are signed and notarized for enhanced security and compliance with macOS requirements.

### GitHub Actions Workflow Updates for Notarization:
* [`.github/workflows/menlo-build.yml`](diffhunk://#diff-b33a723c0ec237567c1e3beb2a35862c6ae91fd2f16d87f93e24b4ccd0509ae9R402-R426): Added steps to install Quill, prepare the notary key, notarize macOS binaries, and clean up the notary key. These steps are conditional on the runner's operating system being macOS.

### Updates to `Makefile` for Notarization:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R14-R17): Introduced new configuration variables (`NOTARIZE`, `QUILL_NOTARY_KEY_ID`, `QUILL_NOTARY_ISSUER`, `QUILL_NOTARY_KEY`) to support notarization. Default values are provided.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R52-R78): Added a new `notarize` target to handle notarization logic. The target skips notarization for non-macOS platforms and performs notarization for macOS binaries using Quill.