### PR TITLE
chore: update notarization makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,17 +63,7 @@ else ifeq ($(shell uname -s),Linux)
 	@exit 0
 else
 	@echo "Starting notarization for macOS binaries..."
-	@find build/bin -type f -exec | while read binary; do \
-		echo "Notarizing $$(basename $$binary)..."; \
-		quill notarize "$$binary"; \
-		if [ $$? -eq 0 ]; then \
-			echo "Successfully notarized $$(basename $$binary)"; \
-		else \
-			echo  Failed to notarize $$(basename $$binary)"; \
-			exit 1; \
-		fi; \
-	done
-	@echo "All macOS binaries notarized successfully"
+	@find build/bin -type f -exec env QUILL_NOTARY_KEY_ID="$(QUILL_NOTARY_KEY_ID)" QUILL_NOTARY_ISSUER="$(QUILL_NOTARY_ISSUER)" QUILL_NOTARY_KEY="$(QUILL_NOTARY_KEY)" quill notarize {} \;
 endif
 
 package:


### PR DESCRIPTION
This pull request updates the notarization process for macOS binaries in the `Makefile` to streamline the workflow and improve maintainability.

### Updates to macOS notarization process:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L66-R66): Replaced the loop-based notarization process with a single `find` command that directly invokes the `quill notarize` command. The new approach passes environment variables (`QUILL_NOTARY_KEY_ID`, `QUILL_NOTARY_ISSUER`, and `QUILL_NOTARY_KEY`) to the `quill` tool, simplifying the script and removing redundant checks.