### PR TITLE
chore: notarize bin for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ else ifeq ($(shell uname -s),Linux)
 	@exit 0
 else
 	@echo "Starting notarization for macOS binaries..."
-	@find build/bin -type f -exec env QUILL_NOTARY_KEY_ID="$(QUILL_NOTARY_KEY_ID)" QUILL_NOTARY_ISSUER="$(QUILL_NOTARY_ISSUER)" QUILL_NOTARY_KEY="$(QUILL_NOTARY_KEY)" quill notarize {} \;
+	@find build/bin -type f -executable -exec env QUILL_NOTARY_KEY_ID="$(QUILL_NOTARY_KEY_ID)" QUILL_NOTARY_ISSUER="$(QUILL_NOTARY_ISSUER)" QUILL_NOTARY_KEY="$(QUILL_NOTARY_KEY)" quill notarize {} \;
 endif
 
 package:


### PR DESCRIPTION
This pull request includes a small but important change to the `Makefile` to improve the notarization process for macOS binaries.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L66-R66): Updated the `find` command in the notarization step to include the `-executable` flag, ensuring that only executable files are passed to the `quill notarize` command.