### PR TITLE
ci: increase timeout for build and test job

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -56,7 +56,7 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.runs-on }}
     needs: [create-draft-release]
-    timeout-minutes: 100
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request makes a minor adjustment to the build workflow by increasing the timeout for the `build-and-test` job in `.github/workflows/menlo-build.yml` from 100 minutes to 180 minutes. This change allows more time for builds and tests to complete without timing out.