### PR TITLE
chore: increase timeout for menlo build

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -56,7 +56,7 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.runs-on }}
     needs: [create-draft-release]
-    timeout-minutes: 180
+    timeout-minutes: 270
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request increases the timeout for the `build-and-test` job in the GitHub Actions workflow to allow more time for builds and tests to complete.

* Increased the `timeout-minutes` for the `build-and-test` job in `.github/workflows/menlo-build.yml` from 180 to 270 minutes.