### PR TITLE
chore: Simplify CI CMake flags by removing redundant options

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -64,7 +64,7 @@ jobs:
           - os: "linux"
             name: "noavx-x64"
             runs-on: "ubuntu-20-04"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -72,7 +72,7 @@ jobs:
           - os: "linux"
             name: "avx-x64"
             runs-on: "ubuntu-20-04"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -80,7 +80,7 @@ jobs:
           - os: "linux"
             name: "avx512-x64"
             runs-on: "ubuntu-20-04"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -88,7 +88,7 @@ jobs:
           - os: "linux"
             name: "noavx-cuda-cu11.7-x64"
             runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -96,7 +96,7 @@ jobs:
           - os: "linux"
             name: "avx2-cuda-cu11.7-x64"
             runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -104,7 +104,7 @@ jobs:
           - os: "linux"
             name: "avx-cuda-cu11.7-x64"
             runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -112,7 +112,7 @@ jobs:
           - os: "linux"
             name: "avx512-cuda-cu11.7-x64"
             runs-on: "ubuntu-20-04-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -120,7 +120,7 @@ jobs:
           - os: "linux"
             name: "noavx-cuda-cu12.0-x64"
             runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -128,7 +128,7 @@ jobs:
           - os: "linux"
             name: "avx2-cuda-cu12.0-x64"
             runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -136,7 +136,7 @@ jobs:
           - os: "linux"
             name: "avx-cuda-cu12.0-x64"
             runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -144,7 +144,7 @@ jobs:
           - os: "linux"
             name: "avx512-cuda-cu12.0-x64"
             runs-on: "ubuntu-20-04-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON "
             run-e2e: false
             vulkan: false
             ccache: true
@@ -152,7 +152,7 @@ jobs:
           - os: "linux"
             name: "vulkan-x64"
             runs-on: "ubuntu-22-04"
-            cmake-flags: "-DBUILD_SHARED_LIBS=OFF -DGGML_VULKAN=ON -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE='Release' -GNinja"
+            cmake-flags: "-DBUILD_SHARED_LIBS=OFF -DGGML_VULKAN=ON -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF "
             run-e2e: false
             vulkan: true
             ccache: true
@@ -176,7 +176,7 @@ jobs:
           - os: "win"
             name: "noavx-cuda-cu12.0-x64"
             runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -184,7 +184,7 @@ jobs:
           - os: "win"
             name: "avx2-cuda-cu12.0-x64"
             runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -192,7 +192,7 @@ jobs:
           - os: "win"
             name: "avx-cuda-cu12.0-x64"
             runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -200,7 +200,7 @@ jobs:
           - os: "win"
             name: "avx512-cuda-cu12.0-x64"
             runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON  -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON  -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -208,7 +208,7 @@ jobs:
           - os: "win"
             name: "noavx-cuda-cu11.7-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -216,7 +216,7 @@ jobs:
           - os: "win"
             name: "avx2-cuda-cu11.7-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -224,7 +224,7 @@ jobs:
           - os: "win"
             name: "avx-cuda-cu11.7-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -232,7 +232,7 @@ jobs:
           - os: "win"
             name: "avx512-cuda-cu11.7-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF  -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
             run-e2e: false
             vulkan: false
             ccache: true
@@ -240,7 +240,7 @@ jobs:
           - os: "win"
             name: "avx2-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF  -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF  -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl"
             run-e2e: true
             vulkan: false
             ccache: false
@@ -248,7 +248,7 @@ jobs:
           - os: "win"
             name: "noavx-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DBUILD_SHARED_LIBS=OFF  -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DBUILD_SHARED_LIBS=OFF  -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl "
             run-e2e: false
             vulkan: false
             ccache: false
@@ -256,7 +256,7 @@ jobs:
           - os: "win"
             name: "avx-x64"
             runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF  -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX2=OFF -DGGML_NATIVE=OFF  -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl "
             run-e2e: true
             vulkan: false
             ccache: false
@@ -264,7 +264,7 @@ jobs:
           - os: "win"
             name: "avx512-x64"
             runs-on: "windows-cuda-12-0"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF  -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_AVX512=ON -DGGML_NATIVE=OFF  -DLLAMA_BLAS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl "
             run-e2e: false
             vulkan: false
             ccache: false
@@ -272,7 +272,7 @@ jobs:
           - os: "win"
             name: "vulkan-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DBUILD_SHARED_LIBS=OFF  -DGGML_VULKAN=ON -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -GNinja"
+            cmake-flags: "-DBUILD_SHARED_LIBS=OFF  -DGGML_VULKAN=ON -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl "
             vulkan: true
             run-e2e: false
             ccache: false


### PR DESCRIPTION
The GitHub Actions workflow menlo-build.yml has been cleaned up:

Stripped out explicit -DCMAKE_CXX_COMPILER_LAUNCHER=ccache / -DCMAKE_C_COMPILER_LAUNCHER=ccache (and the CUDA launcher) from all Linux and Windows jobs.

Removed hard‑coded -DCMAKE_BUILD_TYPE='Release' and -GNinja arguments, relying on defaults or other configuration.

Kept only the essential feature toggles (e.g., -DLLAMA_CURL=OFF, -DGGML_AVX*, -DGGML_CUDA=ON, -DGGML_VULKAN=ON, -DBUILD_SHARED_LIBS=OFF) and the necessary CUDA or Vulkan flags.

Updated both Linux and Windows matrix entries accordingly, preserving run-e2e, vulkan, and ccache settings where appropriate.

This makes the CI configuration more concise and reduces unnecessary duplication.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
