### PR TITLE
chore: update cmake flags for avx2-cuda-11.7

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -217,7 +217,7 @@ jobs:
           - os: "win"
             name: "avx2-cuda-cu11.7-x64"
             runs-on: "windows-cuda-11-7"
-            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release'"
+            cmake-flags: "-DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE='Release' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -GNinja"
             run-e2e: false
             vulkan: false
             ccache: true


### PR DESCRIPTION
This pull request makes a targeted improvement to the Windows CUDA build configuration in the GitHub Actions workflow. The main change is the addition of `ccache` as a compiler launcher for C, C++, and CUDA compilers, and switching the build system to Ninja, which should help speed up build times and improve efficiency for CI builds.

Build process optimizations:

* [`.github/workflows/menlo-build.yml`](diffhunk://#diff-b33a723c0ec237567c1e3beb2a35862c6ae91fd2f16d87f93e24b4ccd0509ae9L220-R220): Updated the `cmake-flags` for the `avx2-cuda-cu11.7-x64` job to use `ccache` as the compiler launcher for C, C++, and CUDA compilers and to use the Ninja generator (`-GNinja`).