### PR TITLE
fix: release file

### DIFF
--- a/.github/workflows/release-aws-s3.yml
+++ b/.github/workflows/release-aws-s3.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Derive repo name safely for all events (release/workflow_dispatch)
+      - name: Derive REPO_NAME
+        id: repoinfo
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY##*/}" >> "$GITHUB_ENV"
+          echo "OWNER_NAME=${GITHUB_REPOSITORY%%/*}" >> "$GITHUB_ENV"
+          echo "Repo resolved to: ${GITHUB_REPOSITORY##*/}"
+
       - name: Resolve release (release event or manual by tag)
         id: rel
         uses: actions/github-script@v7
@@ -67,8 +75,16 @@ jobs:
             core.setOutput('name', name);
             core.setOutput('published_at', release.published_at || new Date().toISOString());
             core.setOutput('assets', JSON.stringify(assets));
+
       - name: Prepare assets directory
         run: mkdir -p out meta
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id:     ${{ secrets.CATALOG_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CATALOG_AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ env.AWS_REGION }}
 
       - name: Download assets from GitHub
         run: |
@@ -80,6 +96,21 @@ jobs:
               curl -L --fail -o "$f" "$url"
             done
 
+      - name: Fetch existing releases.json from S3 (if any)
+        env:
+          BUCKET: ${{ env.BUCKET }}
+          REPO_NAME: ${{ env.REPO_NAME }}
+        run: |
+          mkdir -p meta
+          KEY="$REPO_NAME/releases/releases.json"
+          if aws s3api head-object --bucket "$BUCKET" --key "$KEY" >/dev/null 2>&1; then
+            echo "Found $KEY in S3. Downloading..."
+            aws s3 cp "s3://$BUCKET/$KEY" meta/releases.json
+          else
+            echo "No $KEY in S3. Initializing with empty array."
+            echo '[]' > meta/releases.json
+          fi
+
       - name: Build/merge releases.json (keep max N entries)
         env:
           TAG: ${{ steps.rel.outputs.tag }}
@@ -87,6 +118,7 @@ jobs:
           PUBLISHED_AT: ${{ steps.rel.outputs.published_at }}
           CDN_HOST: ${{ env.CDN_HOST }}
           MAX_HISTORY: ${{ env.MAX_HISTORY }}
+          REPO_NAME: ${{ env.REPO_NAME }}
         run: |
           test -f meta/releases.json || echo '[]' > meta/releases.json
           node - <<'NODE'
@@ -98,6 +130,7 @@ jobs:
           const PUBLISHED_AT = process.env.PUBLISHED_AT || new Date().toISOString()
           const CDN = process.env.CDN_HOST
           const MAX = parseInt(process.env.MAX_HISTORY || '20', 10)
+          const REPO = process.env.REPO_NAME
 
           const files = fs.readdirSync('out')
           const sizeOf = f => fs.statSync(path.join('out', f)).size
@@ -109,7 +142,8 @@ jobs:
             assets: files.map(f => ({
               name: f,
               size: sizeOf(f),
-              browser_download_url: `https://${CDN}/releases/${TAG}/${f}`
+              // URL now includes repo prefix
+              browser_download_url: `https://${CDN}/${REPO}/releases/${TAG}/${f}`
             }))
           }
 
@@ -127,34 +161,34 @@ jobs:
           fs.writeFileSync(p, JSON.stringify(arr, null, 2))
           NODE
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id:     ${{ secrets.CATALOG_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CATALOG_AWS_SECRET_ACCESS_KEY }}
-          aws-region:            ${{ env.AWS_REGION }}
-
-      - name: Upload assets to S3
+      - name: Upload assets to S3 (repo-scoped path)
         env:
           TAG: ${{ steps.rel.outputs.tag }}
           BUCKET: ${{ env.BUCKET }}
+          REPO_NAME: ${{ env.REPO_NAME }}
         run: |
-          echo "Uploading assets for tag $TAG to s3://$BUCKET/releases/$TAG/"
-          aws s3 sync out "s3://$BUCKET/releases/$TAG/"
+          DEST="s3://$BUCKET/$REPO_NAME/releases/$TAG/"
+          echo "Uploading assets for tag $TAG to $DEST"
+          aws s3 sync out "$DEST"
 
-      - name: Update 'latest' alias in S3
+      - name: Update 'latest' alias in S3 (repo-scoped)
         env:
           TAG: ${{ steps.rel.outputs.tag }}
           BUCKET: ${{ env.BUCKET }}
+          REPO_NAME: ${{ env.REPO_NAME }}
         run: |
+          LATEST_PREFIX="s3://$BUCKET/$REPO_NAME/releases/latest/"
+          TAG_PREFIX="s3://$BUCKET/$REPO_NAME/releases/$TAG/"
           echo "Updating 'latest' alias to point to tag $TAG"
-          aws s3 rm "s3://$BUCKET/releases/latest/" --recursive || true
-          aws s3 sync "s3://$BUCKET/releases/$TAG/" "s3://$BUCKET/releases/latest/"
+          aws s3 rm "$LATEST_PREFIX" --recursive || true
+          aws s3 sync "$TAG_PREFIX" "$LATEST_PREFIX"
 
-      - name: Upload releases.json
+      - name: Upload releases.json (repo-scoped)
         env:
           BUCKET: ${{ env.BUCKET }}
+          REPO_NAME: ${{ env.REPO_NAME }}
         run: |
-          echo "Uploading releases.json"
-          aws s3 cp meta/releases.json "s3://$BUCKET/releases/releases.json" \
+          KEY="$REPO_NAME/releases/releases.json"
+          echo "Uploading releases.json to s3://$BUCKET/$KEY"
+          aws s3 cp meta/releases.json "s3://$BUCKET/$KEY" \
             --content-type 'application/json' --cache-control 'no-store'


### PR DESCRIPTION
This pull request updates the `release-aws-s3.yml` GitHub Actions workflow to make S3 release asset uploads and metadata repo-scoped, improving multi-repository support and organization. The workflow now dynamically determines the repository name, stores assets and metadata in repo-specific paths in S3, and updates all related URLs and references accordingly.

**Repo-scoped S3 storage and metadata:**

* Assets and metadata (`releases.json`) are now uploaded to S3 under a per-repository prefix (e.g., `<repo>/releases/`), instead of a shared global path. This ensures releases from different repositories do not conflict and are easier to manage. [[1]](diffhunk://#diff-eab23ea655e225f5395337686145e8c2c0af9af13f60f7679e56389be8968330R27-R34) [[2]](diffhunk://#diff-eab23ea655e225f5395337686145e8c2c0af9af13f60f7679e56389be8968330R99-R121) [[3]](diffhunk://#diff-eab23ea655e225f5395337686145e8c2c0af9af13f60f7679e56389be8968330L130-R193)
* The workflow dynamically derives the repository name and owner using the `GITHUB_REPOSITORY` environment variable, making the workflow reusable across repositories.

**Release asset and metadata handling:**

* The workflow fetches the existing `releases.json` from the repo-scoped S3 path (if it exists) or initializes it as an empty array, ensuring release history is maintained per repository.
* The `browser_download_url` in the generated metadata now includes the repository prefix, so clients can fetch assets from the correct S3 location. [[1]](diffhunk://#diff-eab23ea655e225f5395337686145e8c2c0af9af13f60f7679e56389be8968330R133) [[2]](diffhunk://#diff-eab23ea655e225f5395337686145e8c2c0af9af13f60f7679e56389be8968330L112-R146)

**AWS credentials and S3 operations:**

* The AWS credentials configuration step is moved earlier, before any S3 operations, to ensure all S3 commands have the necessary permissions.
* All S3 upload and sync commands are updated to use the repo-scoped paths for assets, the `latest` alias, and `releases.json`.