### PR TITLE
Fix ci trigger

### DIFF
--- a/.github/workflows/release-aws-s3.yml
+++ b/.github/workflows/release-aws-s3.yml
@@ -2,7 +2,7 @@ name: Mirror Releases to S3
 
 on:
   release:
-    types: [published]
+    types: [published, released, edited]
   workflow_dispatch:
     inputs:
       tag_name:


### PR DESCRIPTION
This pull request expands the triggers for the "Mirror Releases to S3" GitHub Actions workflow to ensure it runs on additional release-related events.

Workflow trigger updates:

* [`.github/workflows/release-aws-s3.yml`](diffhunk://#diff-eab23ea655e225f5395337686145e8c2c0af9af13f60f7679e56389be8968330L5-R5): The workflow will now run not only on the `published` event, but also on `released` and `edited` events for releases.