### PR TITLE
ci: ad docker runner image for cuda

### DIFF
--- a/.github/runners/actions-runner-ubuntu-cuda-11-7-ubuntu-2204.dockerfile
+++ b/.github/runners/actions-runner-ubuntu-cuda-11-7-ubuntu-2204.dockerfile
@@ -1,0 +1,94 @@
+# Use NVIDIA CUDA 11.7.1 development image with Ubuntu 22.04 as the base
+FROM nvidia/cuda:11.7.1-devel-ubuntu22.04
+
+# Docker and Docker Compose arguments
+
+# Use 1001 and 121 for compatibility with GitHub-hosted runners
+ARG RUNNER_UID=1000
+ARG DOCKER_GID=1001
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install necessary packages
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    ca-certificates \
+    dnsutils \
+    ftp \
+    git \
+    uuid-dev \
+    iproute2 \
+    iputils-ping \
+    jq \
+    libunwind8 \
+    locales \
+    netcat \
+    openssh-client \
+    parallel \
+    python3-pip \
+    rsync \
+    shellcheck \
+    sudo \
+    telnet \
+    time \
+    tzdata \
+    unzip \
+    upx \
+    wget \
+    lsb-release \
+    openssl \
+    libssl-dev \
+    manpages-dev \
+    zip \
+    zstd \
+    pkg-config \
+    ccache \
+    gcc \
+    g++ \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Kitware's APT repository for CMake
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
+    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
+    apt-get update && \
+    apt-get install -y cmake
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
+
+RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner \
+    && groupadd docker --gid $DOCKER_GID \
+    && usermod -aG sudo runner \
+    && usermod -aG docker runner \
+    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
+
+ENV HOME=/home/runner
+
+ARG RUNNER_VERSION=2.328.0
+
+# cd into the user directory, download and unzip the github actions runner
+RUN cd /home/runner && mkdir actions-runner && cd actions-runner \
+    && curl -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+
+RUN chown -R runner:runner /home/runner && /home/runner/actions-runner/bin/installdependencies.sh
+
+ADD ./start.sh /home/runner/start.sh
+
+RUN chmod +x /home/runner/start.sh
+
+# Add /usr/local/cuda-11.7/compat to LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/cuda-11.7/compat${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+ENTRYPOINT ["/bin/bash", "/home/runner/start.sh"]
+
+USER runner

--- a/.github/runners/actions-runner-ubuntu-cuda-12-4-ubuntu-2204.dockerfile
+++ b/.github/runners/actions-runner-ubuntu-cuda-12-4-ubuntu-2204.dockerfile
@@ -1,0 +1,93 @@
+# Use NVIDIA CUDA 12.4.0 development image with Ubuntu 22.04 as the base
+FROM nvidia/cuda:12.4.0-devel-ubuntu22.04
+# Docker and Docker Compose arguments
+
+# Use 1001 and 121 for compatibility with GitHub-hosted runners
+ARG RUNNER_UID=1000
+ARG DOCKER_GID=1001
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install necessary packages
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    ca-certificates \
+    dnsutils \
+    ftp \
+    git \
+    uuid-dev \
+    iproute2 \
+    iputils-ping \
+    jq \
+    libunwind8 \
+    locales \
+    netcat \
+    openssh-client \
+    parallel \
+    python3-pip \
+    rsync \
+    shellcheck \
+    sudo \
+    telnet \
+    time \
+    tzdata \
+    unzip \
+    upx \
+    wget \
+    lsb-release \
+    openssl \
+    libssl-dev \
+    manpages-dev \
+    zip \
+    zstd \
+    pkg-config \
+    ccache \
+    gcc \
+    g++ \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Kitware's APT repository for CMake
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
+    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
+    apt-get update && \
+    apt-get install -y cmake
+
+# Download latest git-lfs version
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y --no-install-recommends git-lfs
+
+RUN adduser --disabled-password --gecos "" --uid $RUNNER_UID runner \
+    && groupadd docker --gid $DOCKER_GID \
+    && usermod -aG sudo runner \
+    && usermod -aG docker runner \
+    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
+
+ENV HOME=/home/runner
+
+ARG RUNNER_VERSION=2.328.0
+
+# cd into the user directory, download and unzip the github actions runner
+RUN cd /home/runner && mkdir actions-runner && cd actions-runner \
+    && curl -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+
+RUN chown -R runner:runner /home/runner && /home/runner/actions-runner/bin/installdependencies.sh
+
+ADD ./start.sh /home/runner/start.sh
+
+RUN chmod +x /home/runner/start.sh
+
+# Add /usr/local/cuda-11.7/compat to LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/cuda-11.7/compat${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+ENTRYPOINT ["/bin/bash", "/home/runner/start.sh"]
+
+USER runner

--- a/.github/runners/start.sh
+++ b/.github/runners/start.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+RUNNER_REPO=$RUNNER_REPO
+RUNNER_PAT=$RUNNER_PAT
+RUNNER_GROUP=$RUNNER_GROUP
+RUNNER_LABELS=$RUNNER_LABELS
+RUNNER_NAME=$(hostname)
+
+# Get the latest version of the GitHub Actions runner
+LATEST_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep -oP '(?<=\"tag_name\": \"v)[^\"]*')
+OS_ARCH=$(uname -m)
+
+if [[ "$OS_ARCH" == "x86_64" ]]; then
+    ARCH="x64"
+elif [[ "$OS_ARCH" == "aarch64" ]]; then
+    ARCH="arm64"
+else
+    echo "Unsupported architecture: $OS_ARCH"
+    exit 1
+fi
+
+# Download and install the GitHub Actions runner
+cd /home/runner && rm -rf actions-runner && mkdir -p actions-runner && cd actions-runner
+curl -O -L https://github.com/actions/runner/releases/download/v${LATEST_VERSION}/actions-runner-linux-${ARCH}-${LATEST_VERSION}.tar.gz
+
+tar xzf ./actions-runner-linux-${ARCH}-${LATEST_VERSION}.tar.gz
+
+# Navigate to actions-runner directory
+cd /home/runner/actions-runner
+
+./config.sh --unattended --replace --url https://github.com/${RUNNER_REPO} \
+    --pat ${RUNNER_PAT} \
+    --name ${RUNNER_NAME} \
+    --runnergroup ${RUNNER_GROUP} \
+    --labels ${RUNNER_LABELS} \
+    --work /home/runner/actions-runner/_work
+
+cleanup() {
+    echo "Removing runner..."
+    ./config.sh remove --unattended --pat ${RUNNER_PAT}
+}
+
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+./run.sh & wait $!


### PR DESCRIPTION
This pull request introduces new Dockerfiles for GitHub Actions runners with CUDA support and adds an entrypoint script to automate runner setup and lifecycle management. The most important changes are grouped below:

**New Dockerfiles for CUDA-enabled runners:**

* Added `.github/runners/actions-runner-ubuntu-cuda-11-7-ubuntu-2204.dockerfile` to provide a GitHub Actions runner environment based on NVIDIA CUDA 11.7.1 and Ubuntu 22.04, with all necessary build tools, Python, CMake, and git-lfs installed.
* Added `.github/runners/actions-runner-ubuntu-cuda-12-4-ubuntu-2204.dockerfile` to provide a similar runner environment but based on NVIDIA CUDA 12.4.0.

**Automation and runner lifecycle:**

* Added `.github/runners/start.sh` script to automate downloading the latest Actions runner, configuring it with environment variables, handling architecture detection, and providing cleanup on termination signals.