### PR TITLE
chore: update runner image command

### DIFF
--- a/.github/runners/actions-runner-ubuntu-cuda-11-7-ubuntu-2204.dockerfile
+++ b/.github/runners/actions-runner-ubuntu-cuda-11-7-ubuntu-2204.dockerfile
@@ -82,9 +82,9 @@ RUN cd /home/runner && mkdir actions-runner && cd actions-runner \
 
 RUN chown -R runner:runner /home/runner && /home/runner/actions-runner/bin/installdependencies.sh
 
-ADD ./start.sh /home/runner/start.sh
+ADD --chown=runner:runner ./start.sh /home/runner/start.sh
 
-RUN chmod +x /home/runner/start.sh
+RUN chmod 755 /home/runner/start.sh
 
 # Add /usr/local/cuda-11.7/compat to LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/cuda-11.7/compat${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}

--- a/.github/runners/actions-runner-ubuntu-cuda-12-4-ubuntu-2204.dockerfile
+++ b/.github/runners/actions-runner-ubuntu-cuda-12-4-ubuntu-2204.dockerfile
@@ -81,9 +81,9 @@ RUN cd /home/runner && mkdir actions-runner && cd actions-runner \
 
 RUN chown -R runner:runner /home/runner && /home/runner/actions-runner/bin/installdependencies.sh
 
-ADD ./start.sh /home/runner/start.sh
+ADD --chown=runner:runner ./start.sh /home/runner/start.sh
 
-RUN chmod +x /home/runner/start.sh
+RUN chmod 755 /home/runner/start.sh
 
 # Add /usr/local/cuda-11.7/compat to LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/cuda-11.7/compat${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}


### PR DESCRIPTION
This pull request updates the Dockerfiles for the CUDA 11.7 and 12.4 GitHub Actions runners to improve file permissions and ownership handling for the `start.sh` script. The changes ensure that the script is properly owned by the `runner` user and has the correct executable permissions.