### PR TITLE
ci: deprecate macos-selfhosted-12 build runner

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -198,14 +198,15 @@ jobs:
             vulkan: true
             ccache: true
             ccache-dir: "/home/runner/.ccache"
-          - os: "macos"
-            name: "x64"
-            runs-on: "macos-selfhosted-12"
-            cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=ON"
-            run-e2e: false
-            vulkan: false
-            ccache: false
-            ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+          # DEPRECATED: macos-selfhosted-12 (Intel x64) runner is being phased out.
+          # - os: "macos"
+          #   name: "x64"
+          #   runs-on: "macos-selfhosted-12"
+          #   cmake-flags: "-DCMAKE_BUILD_RPATH=\"@loader_path\" -DGGML_METAL=OFF -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=ON"
+          #   run-e2e: false
+          #   vulkan: false
+          #   ccache: false
+          #   ccache-dir: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
           - os: "macos"
             name: "arm64"
             runs-on: "macos-selfhosted-14-arm64"


### PR DESCRIPTION
This pull request updates the build workflow configuration by deprecating the Intel x64 macOS runner in favor of more current runners. The main change is the removal (by commenting out) of the `macos-selfhosted-12` (Intel x64) job from the `.github/workflows/menlo-build.yml` file.

Build workflow updates:

* Commented out the `macos-selfhosted-12` (Intel x64) runner configuration, marking it as deprecated and indicating it is being phased out. This job will no longer be executed in CI builds.