### PR TITLE
ci: fix missing -bin- segment in checksum.yml asset URLs

### DIFF
--- a/.github/workflows/menlo-build.yml
+++ b/.github/workflows/menlo-build.yml
@@ -667,7 +667,7 @@ jobs:
             .sha512 as $sha512 |
             .size as $size |
             (.sha512 | keys[]) as $key |
-            "- url: llama-\($version)-\($key).tar.gz\n  sha512: >-\n    \($sha512[$key])\n  size: \($size[$key])"
+            "- url: llama-\($version)-bin-\($key).tar.gz\n  sha512: >-\n    \($sha512[$key])\n  size: \($size[$key])"
           ' >> checksum.yml
 
           echo "- url: cudart-llama-bin-linux-cu13.0-x64.tar.gz" >> checksum.yml


### PR DESCRIPTION
The release assets upload as llama-<version>-bin-<os>-<name>.tar.gz, but the jq template generating checksum.yml emitted llama-<version>-<os>-<name>.tar.gz, so a lookup keyed on the downloaded filename matched no backend archive.